### PR TITLE
Add redux reducer support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,7 @@
+version: 2.1
+orbs:
+  node: circleci/node@3.0.0
+workflows:
+  node-tests:
+    jobs:
+      - node/test

--- a/__tests__/addHoney.test.js
+++ b/__tests__/addHoney.test.js
@@ -2,7 +2,7 @@ import { addHoney } from "../";
 
 test("creating state with addHoney", () => {
 
-  const testState = addHoney("testState", {
+  const testState = addHoney("state", {
     name: "Kody",
     age: 27,
     isFanOfSports: true
@@ -12,6 +12,6 @@ test("creating state with addHoney", () => {
   expect(testState.get).toBeInstanceOf(Function);
   expect(testState.resetKey).toBeInstanceOf(Function);
   expect(testState.reset).toBeInstanceOf(Function);
-  expect(testState.__stateKey).toBe("testState");
+  expect(testState.__stateKey).toBe("state");
   expect(testState.__reducer).toBeInstanceOf(Function);
 })

--- a/__tests__/createHoneyPot.test.js
+++ b/__tests__/createHoneyPot.test.js
@@ -2,7 +2,7 @@ import { createHoneyPot, addHoney } from "../";
 
 test("Creates store honey pot", () => {
 
-  const testState = addHoney("testState", {
+  const testState = addHoney("state", {
     name: "Kody",
     age: 28
   });

--- a/__tests__/getRootReducer.test.js
+++ b/__tests__/getRootReducer.test.js
@@ -1,0 +1,27 @@
+import { addHoney, createHoneyPot } from "../";
+
+describe("getRootReducer properly creates a root reducer", () => {
+  
+  test("accepts addHoney state", () => {
+    const testState = addHoney("testState", {
+      name: "Kody",
+      age: 28
+    });
+    
+    expect(createHoneyPot({ testState })).toBeInstanceOf(Object);
+  });
+  
+  test("accepts redux state", () => {
+    
+    const initialState = {
+      name: "Kody",
+      age: 28
+    }
+    
+    const testReducer = (state = initialState, { type, payload }) => {
+      
+    }
+    
+    expect(createHoneyPot({ testState })).toBeInstanceOf(Object);
+  });
+})

--- a/__tests__/getRootReducer.test.js
+++ b/__tests__/getRootReducer.test.js
@@ -2,16 +2,11 @@ import { addHoney, createHoneyPot } from "../";
 
 describe("getRootReducer properly creates a root reducer", () => {
   
-  test("accepts addHoney state", () => {
+  test("accepts addHoney state & redux reducer", () => {
     const testState = addHoney("testState", {
       name: "Kody",
       age: 28
     });
-    
-    expect(createHoneyPot({ testState })).toBeInstanceOf(Object);
-  });
-  
-  test("accepts redux state", () => {
     
     const initialState = {
       name: "Kody",
@@ -19,9 +14,16 @@ describe("getRootReducer properly creates a root reducer", () => {
     }
     
     const testReducer = (state = initialState, { type, payload }) => {
-      
+      switch(type) {
+        case "SET_NAME":
+          return { ...state, name: payload.name };
+        case "SET_AGE":
+          return { ...state, age: payload.age };
+        default:
+          return state;
+      }
     }
     
-    expect(createHoneyPot({ testState })).toBeInstanceOf(Object);
-  });
+    expect(createHoneyPot({ testState, testReducer })).toBeInstanceOf(Object);
+  });  
 })

--- a/__tests__/getState.test.js
+++ b/__tests__/getState.test.js
@@ -2,7 +2,7 @@ import { addHoney, createHoneyPot } from "../";
 
 describe("state.get properly returns values", () => {
   
-  const state = addHoney("state", {
+  const testState = addHoney("state", {
     name: "Kody",
     age: 28,
     isFanOfSports: true,
@@ -13,28 +13,28 @@ describe("state.get properly returns values", () => {
     favFoods: ["pizza", "burgers", "steak"]
   });
 
-  createHoneyPot({ state });
+  createHoneyPot({ testState });
   
   test("state.get properly returns string value", () => {
-    expect(state.get("name")).toBe("Kody");
+    expect(testState.get("name")).toBe("Kody");
   });
   
   test("state.get properly returns numeric value", () => {
-    expect(state.get("age")).toBe(28);
+    expect(testState.get("age")).toBe(28);
   })
   
   test("state.get properly returns boolean value", () => {
-    expect(state.get("isFanOfSports")).toBe(true);
+    expect(testState.get("isFanOfSports")).toBe(true);
   });
   
   test("state.get properly returns array value", () => {
-    expect(state.get("friends")).toBeInstanceOf(Array);
-    expect(state.get("friends")).toHaveLength(0);
-    expect(state.get("favFoods")[2]).toBe("steak");
+    expect(testState.get("friends")).toBeInstanceOf(Array);
+    expect(testState.get("friends")).toHaveLength(0);
+    expect(testState.get("favFoods")[2]).toBe("steak");
   });
   
   test("state.get properly returns object", () => {
-    expect(state.get("aboutMe")).toBeInstanceOf(Object);
-    expect(state.get("aboutMe.isTall")).toBe(false);
+    expect(testState.get("aboutMe")).toBeInstanceOf(Object);
+    expect(testState.get("aboutMe.isTall")).toBe(false);
   });
 });

--- a/__tests__/setState.test.js
+++ b/__tests__/setState.test.js
@@ -2,7 +2,7 @@ import { addHoney, createHoneyPot } from "../";
 
 describe("state.set properly sets values", () => {
   
-  const state = addHoney("state", {
+  const testState = addHoney("state", {
     name: "Kody",
     age: 28,
     isFanOfSports: true,
@@ -13,31 +13,31 @@ describe("state.set properly sets values", () => {
     favFoods: ["pizza", "burgers", "steak"]
   });
 
-  createHoneyPot({ state });
+  createHoneyPot({ testState });
   
   test("state.set properly sets string values", () => {
-    expect(state.get("name")).toBe("Kody");
-    state.set({ name: "Sarah" });
-    expect(state.get("name")).toBe("Sarah");
+    expect(testState.get("name")).toBe("Kody");
+    testState.set({ name: "Sarah" });
+    expect(testState.get("name")).toBe("Sarah");
   });
   
   test("state.set properly sets numeric values", () => {
-    expect(state.get("age")).toBe(28);
-    state.set({ age: 30 });
-    expect(state.get("age")).toBe(30);
+    expect(testState.get("age")).toBe(28);
+    testState.set({ age: 30 });
+    expect(testState.get("age")).toBe(30);
   });
   
   test("state.set properly sets boolean values", () => {
-    expect(state.get("isFanOfSports")).toBe(true);
-    state.set({ isFanOfSports: false });
-    expect(state.get("isFanOfSports")).toBe(false);
+    expect(testState.get("isFanOfSports")).toBe(true);
+    testState.set({ isFanOfSports: false });
+    expect(testState.get("isFanOfSports")).toBe(false);
   });
   
   test("state.set properly sets object values", () => {
-    expect(state.get("aboutMe.isTall")).toBe(false);
-    const aboutMe = state.get("aboutMe");
+    expect(testState.get("aboutMe.isTall")).toBe(false);
+    const aboutMe = testState.get("aboutMe");
     aboutMe.isTall = true;
-    state.set({ aboutMe });
-    expect(state.get("aboutMe.isTall")).toBe(true);
+    testState.set({ aboutMe });
+    expect(testState.get("aboutMe.isTall")).toBe(true);
   })
 })

--- a/index.js
+++ b/index.js
@@ -122,28 +122,41 @@ const getRootReducer = (combinedState) => {
 
 	const rootReducer = {};
 
-	Object.keys(combinedState).forEach((stateKey, index) => {
+	Object.keys(combinedState).forEach((objectKey, index) => {
 
-		const state = combinedState[stateKey];
+		const state = combinedState[objectKey];
 
-		if (!state.__reducer)
-			return log.error(`Passed state ${stateKey} into createHoneyPot() was not created with addHoney()`);
-
-		rootReducer[stateKey] = state.__reducer;
-
-		delete state.__reducer;
+		if (!isReducerOrAddHoney(state)) {
+			log.error(`Passed state ${(isAddHoney(state)) ? state.__stateKey : ""} into createHoneyPot() was not created with addHoney()`);
+		}
+		
+		if (typeof state === "function") {
+			rootReducer[state.__stateKey] = state;
+		} else if (typeof state === "object" && state.__reducer) {
+			rootReducer[state.__stateKey] = state.__reducer;
+			delete state.__reducer;
+		}
 	});
 
 	return combineReducers(rootReducer);
 }
 
+const isReducerOrAddHoney = (state) => (
+	typeof state === "function" || isAddHoney(state)
+)
+
+const isAddHoney = (object) => {
+	!Array.isArray(object)
+	&& typeof object === "object"
+	&& object.__reducer
+}
+
 const createReducer = (stateKey, initialState) => (
-	(state = initialState, { type, payload }) => ((type === stateKey)
+	(state = initialState, { type, payload }) => (type === stateKey)
 		? updateState(state, payload)
 		: (type === RESET_STORE)
 		? deepClone(initialStates[stateKey])
 		: state
-	)
 )
 
 const updateState = (state, payload) => (

--- a/index.js
+++ b/index.js
@@ -125,19 +125,19 @@ const getRootReducer = (combinedState) => {
 	Object.keys(combinedState).forEach((objectKey, index) => {
 
 		const state = combinedState[objectKey];
-
+		
 		if (!isReducerOrAddHoney(state)) {
-			log.error(`Passed state ${(isAddHoney(state)) ? state.__stateKey : ""} into createHoneyPot() was not created with addHoney()`);
+			log.error(`Passed state ${(isAddHoney(state)) ? state.__stateKey : objectKey} into createHoneyPot() was not created with addHoney() nor is a redux reducer`);
 		}
 		
 		if (typeof state === "function") {
-			rootReducer[state.__stateKey] = state;
-		} else if (typeof state === "object" && state.__reducer) {
+			rootReducer[objectKey] = state;
+		} else if (isAddHoney(state)) {
 			rootReducer[state.__stateKey] = state.__reducer;
 			delete state.__reducer;
 		}
 	});
-
+	
 	return combineReducers(rootReducer);
 }
 
@@ -145,11 +145,11 @@ const isReducerOrAddHoney = (state) => (
 	typeof state === "function" || isAddHoney(state)
 )
 
-const isAddHoney = (object) => {
+const isAddHoney = (object) => (
 	!Array.isArray(object)
 	&& typeof object === "object"
-	&& object.__reducer
-}
+	&& object.__reducer !== undefined
+)
 
 const createReducer = (stateKey, initialState) => (
 	(state = initialState, { type, payload }) => (type === stateKey)


### PR DESCRIPTION
- Added support for passing redux reducers into `createHoneyPot`. This is key to allow users to transition their store from redux and not need a hard switch
- Added CircleCI